### PR TITLE
fix(home page): fixed accordion width to be same like slider and adding preview title

### DIFF
--- a/src/components/AccordionAbout.jsx
+++ b/src/components/AccordionAbout.jsx
@@ -3,7 +3,7 @@ import AccordionItem from "./AccordionItem";
 
 export default function AccordionAbout() {
     return (
-        <div className="flex flex-col gap-1 my-10 mx-5">
+        <div className="flex flex-col gap-1 my-5 mx-5 sm:mx-0 sm:justify-center">
             <AccordionItem title={dataAccordion[0].title} content={<div dangerouslySetInnerHTML={{ __html: dataAccordion[0].content }} />} />
             <AccordionItem title={dataAccordion[1].title} content={<div dangerouslySetInnerHTML={{ __html: dataAccordion[1].content }} />} />
         </div>

--- a/src/components/AccordionItem.jsx
+++ b/src/components/AccordionItem.jsx
@@ -12,9 +12,9 @@ export default function AccordionItem({ title, content }) {
     const headingId = `accordion-heading-${title.replace(/\s+/g, "-").toLowerCase()}`;
 
     return (
-        <div onClick={toggleClick} className="border border-[#B6C2E2] rounded-lg hover:cursor-pointer px-5 py-2 font-default">
+        <div onClick={toggleClick} className="border border-[#B6C2E2] rounded-lg hover:cursor-pointer px-5 py-2 font-default sm:w-[75%] sm:self-center md:w-[60%]">
             <div className="flex justify-between">
-                <h2 id={headingId} className="font-semibold text-xl">
+                <h2 id={headingId} className="font-semibold text-lg md:text-xl">
                     {title}
                 </h2>
                 <button aria-labelledby={headingId} onClick={toggleClick}>

--- a/src/pages/Home.page.jsx
+++ b/src/pages/Home.page.jsx
@@ -28,8 +28,11 @@ function HomePage() {
           <p className="font-normal opacity-80">Klik Pulaunya Untuk Detail
             Lebih Lanjut!</p>
         </div>
-        <div className="w-full sm:w-[75%] sm:m-auto md:w-[60%] pt-11">
+        <div className="w-full sm:w-[75%] mt-5 sm:mx-auto md:w-[60%]">
+        <h2 className="text-3xl font-semibold font-default ml-5 sm:ml-0">Preview</h2>
+        <div className="pt-4">
           <Slider slides={slides} />
+        </div>
         </div>
         <AccordionAbout />
       </main>


### PR DESCRIPTION
## Do some design fix
- [x] Accordation should be same as slider width
![Screen Shot 2023-11-20 at 13 40 42](https://github.com/maazshakeel/devdynasty_project/assets/92165681/2c3b26d1-d6a9-4229-ac22-197179e846df)
- [x] Make Accordation text responsive
- [x] Add `Preview` text above slider.
